### PR TITLE
config.sim.loopDelay can now be changed on the fly

### DIFF
--- a/soapy/aoSimLib.py
+++ b/soapy/aoSimLib.py
@@ -684,26 +684,21 @@ def photonsPerMag(mag, mask, pxlScale, wvlBand, expTime):
 ######################
 
 
-class FixedLengthBuffer:
+class DelayBuffer(list):
     '''
-    A fixed length buffer.
+    A delay buffer.
 
-    Each time the buffer is called the input value is stored.
-    If the buffer is full, the oldest value is removed and returned.
-    If the buffer is not yet full, a zero os similar shape as the last input
+    Each time delay() is called on the buffer, the input value is stored.
+    If the buffer is larger than count, the oldest value is removed and returned.
+    If the buffer is not yet full, a zero of similar shape as the last input
     is returned.
-
-    Args:
-        length: length of the buffer.
     '''
 
-    def __init__(self, length):
-        print("Creating buffer of length {0}".format(length))
-        self.buffer = [None] * length
-
-    def __call__(self, value):
-        self.buffer.append(value)
-        result = self.buffer.pop(0)
-        if result is None:
+    def delay(self, value, count):
+        self.append(value)
+        if len(self) <= count:
             result = value*0.0
+        else:
+            for _ in range(len(self)-count):
+                result = self.pop(0)
         return result

--- a/soapy/simulation.py
+++ b/soapy/simulation.py
@@ -281,7 +281,7 @@ class Sim(object):
         self.initSaveData()
 
         #Init simulation
-        self.delay = aoSimLib.FixedLengthBuffer(self.config.sim.loopDelay)
+        self.buffer = aoSimLib.DelayBuffer()
         self.iters=0
 
         #Init performance tracking
@@ -524,7 +524,7 @@ class Sim(object):
             self.dmCommands[:] = self.recon.reconstruct(self.slopes)
 
         # Delay the dmCommands if loopDelay is configured
-        self.dmCommands = self.delay(self.dmCommands)
+        self.dmCommands = self.buffer.delay(self.dmCommands, self.config.sim.loopDelay)
 
         # Get dmShape from closed loop DMs
         self.closedCorrection += self.runDM(


### PR DESCRIPTION
This tweaks the implementation so that at each simulation loop the current value of config.sim.loopDelay is used.