### PR TITLE
New type of science camera: coupling into a single mode fibre

### DIFF
--- a/soapy/SCI.py
+++ b/soapy/SCI.py
@@ -70,8 +70,8 @@ class scienceCam(object):
         # Get phase scaling factor to get r0 in other wavelength
         # phsWvl = 500e-9
         # self.r0Scale = phsWvl / self.sciConfig.wavelength
-        # Convert phase to radians at science wavelength
-        self.phs2Rad = 2*numpy.pi/(self.sciConfig.wavelength*10**9)
+        # Convert phase in nm to radians at science wavelength
+        self.phsNm2Rad = 2*numpy.pi/(self.sciConfig.wavelength*10**9)
 
         # Calculate ideal PSF for purposes of strehl calculation
         self.residual = numpy.zeros((self.simConfig.simSize,) * 2)
@@ -186,8 +186,8 @@ class scienceCam(object):
         # Scaled the padded phase to the right size for the requried FOV
         phs = aoSimLib.zoom(self.residual, self.padFOVPxlNo)
 
-        # Convert phase deviation to radians
-        phs *= self.phs2Rad
+        # Convert phase deviation in nm to radians
+        phs *= self.phsNm2Rad
 
         # Chop out the phase across the pupil before the fft
         coord = int(round((self.padFOVPxlNo - self.FOVPxlNo) / 2.))

--- a/soapy/SCI.py
+++ b/soapy/SCI.py
@@ -247,3 +247,12 @@ class scienceCam(object):
         # self.residual*=self.mask
 
         return self.focalPlane
+
+
+class singleModeFibre(scienceCam):
+
+    def __init__(self, simConfig, telConfig, atmosConfig, sciConfig, mask):
+        scienceCam.__init__(self, simConfig, telConfig, atmosConfig, sciConfig, mask)
+
+    def calcInstStrehl(self):
+        self.instStrehl = numpy.exp(-numpy.var(self.residual[numpy.where(self.mask)]*self.phsNm2Rad))

--- a/soapy/SCI.py
+++ b/soapy/SCI.py
@@ -253,6 +253,8 @@ class singleModeFibre(scienceCam):
 
     def __init__(self, simConfig, telConfig, atmosConfig, sciConfig, mask):
         scienceCam.__init__(self, simConfig, telConfig, atmosConfig, sciConfig, mask)
+        self.fibre_efield = aoSimLib.gaussian2d((self.simConfig.simSize, self.simConfig.simSize), (20.0, 20.0))
+        self.fibre_efield /= numpy.sqrt(numpy.sum(numpy.abs(self.fibre_efield)**2))
 
     def calcInstStrehl(self):
-        self.instStrehl = numpy.exp(-numpy.var(self.residual[numpy.where(self.mask)]*self.phsNm2Rad))
+        self.instStrehl = numpy.abs(numpy.sum(self.fibre_efield * numpy.exp(1j*self.residual*self.phsNm2Rad) * self.mask))**2/numpy.sum(numpy.abs(self.mask)**2)

--- a/soapy/SCI.py
+++ b/soapy/SCI.py
@@ -206,6 +206,15 @@ class scienceCam(object):
         # Normalise the psf
         self.focalPlane /= self.focalPlane.sum()
 
+    def calcInstStrehl(self):
+        """
+        Calculates the instantaneous Strehl, including TT if configured.
+        """
+        if self.sciConfig.instStrehlWithTT:
+            self.instStrehl = self.focalPlane[self.sciConfig.pxls//2,self.sciConfig.pxls//2]/self.focalPlane.sum()/self.psfMax
+        else:
+            self.instStrehl = self.focalPlane.max()/self.focalPlane.sum()/ self.psfMax
+
     def frame(self, scrns, phaseCorrection=None):
         """
         Runs a single science camera frame with one or more phase screens
@@ -232,12 +241,9 @@ class scienceCam(object):
 
         self.calcFocalPlane()
 
+        self.calcInstStrehl()
+
         # Here so when viewing data, that outside of the pupil isn't visible.
         # self.residual*=self.mask
-
-        if self.sciConfig.instStrehlWithTT:
-            self.instStrehl = self.focalPlane[self.sciConfig.pxls//2,self.sciConfig.pxls//2]/self.focalPlane.sum()/self.psfMax
-        else:
-            self.instStrehl = self.focalPlane.max()/self.focalPlane.sum()/ self.psfMax
 
         return self.focalPlane

--- a/soapy/confParse.py
+++ b/soapy/confParse.py
@@ -770,6 +770,9 @@ class SciConfig(ConfigObj):
         ==================== =================================   ===========
         **Parameter**        **Description**                     **Default**
         -------------------- ---------------------------------   -----------
+        ``type``             string: Type of science camera
+                             This must the name of a class
+                             in the ``WFS`` module.              ``scienceCam``
         ``fftOversamp``      int: Multiplied by the number of
                              of phase points required for FOV
                              to increase fidelity from FFT.      ``2``
@@ -795,7 +798,8 @@ class SciConfig(ConfigObj):
                                 "wavelength",
                                 "pxls",
                                 ]
-        self.optionalParams = [ ("fftOversamp", 2),
+        self.optionalParams = [ ("type", "scienceCam"),
+                                ("fftOversamp", 2),
                                 ("fftwFlag", "FFTW_MEASURE"),
                                 ("fftwThreads", 1),
                                 ("instStrehlWithTT", False),

--- a/soapy/gui.py
+++ b/soapy/gui.py
@@ -455,11 +455,11 @@ class GUI(QtGui.QMainWindow):
             del plt
 
         self.strehlPlts=[]
-        if self.config.sim.nSci>0:
-            self.strehlPlts.append(self.strehlAxes.plot(self.sim.instStrehl[0],
-                    linestyle=":", color=self.colorList[self.colorNo]))
-            self.strehlPlts.append(self.strehlAxes.plot(self.sim.longStrehl[0],
-                 color=self.colorList[self.colorNo]))
+        for sci in xrange(self.config.sim.nSci):
+            self.strehlPlts.append(self.strehlAxes.plot(self.sim.instStrehl[sci],
+                    linestyle=":", color=self.colorList[(self.colorNo+sci) % len(self.colorList)]))
+            self.strehlPlts.append(self.strehlAxes.plot(self.sim.longStrehl[sci],
+                 color=self.colorList[(self.colorNo+sci) % len(self.colorList)]))
         self.resultPlot.canvas.draw()
 
     def updateStats(self, itersPerSec, timeRemaining):

--- a/soapy/simulation.py
+++ b/soapy/simulation.py
@@ -223,7 +223,7 @@ class Sim(object):
                      self.wfss[nwfs].activeSubaps*2))
 
         #init DMs
-        logger.info("Initialising DMs...")
+        logger.info("Initialising {0} DMs...".format(self.config.sim.nDM))
         self.dms = {}
         self.dmActCommands = {}
         self.config.sim.totalActs = 0
@@ -261,7 +261,7 @@ class Sim(object):
 
 
         #init Science Cameras
-        logger.info("Initialising Science Cams...")
+        logger.info("Initialising {0} Science Cams...".format(self.config.sim.nSci))
         self.sciCams = {}
         self.sciImgs = {}
         self.sciImgNo=0

--- a/soapy/simulation.py
+++ b/soapy/simulation.py
@@ -224,8 +224,6 @@ class Sim(object):
 
         #init DMs
         logger.info("Initialising DMs...")
-
-
         self.dms = {}
         self.dmActCommands = {}
         self.config.sim.totalActs = 0
@@ -268,7 +266,11 @@ class Sim(object):
         self.sciImgs = {}
         self.sciImgNo=0
         for sci in xrange(self.config.sim.nSci):
-            self.sciCams[sci] = SCI.scienceCam(
+            try:
+                sciObj = eval( "SCI."+self.config.scis[sci].type)
+            except AttributeError:
+                raise confParse.ConfigurationError("No science camera of type {} found".format(self.config.scis[sci].type))
+            self.sciCams[sci] = sciObj(
                         self.config.sim, self.config.tel, self.config.atmos,
                         self.config.scis[sci], self.mask
                         )


### PR DESCRIPTION
There is quite a lot of things in this PR. Beside the cosmetic aspects:
* Added the type of camera as an optional configuration item to Science, defaulting to scienceCam.
* Moved the instantaneous Strehl calculation to a specific method.
* Created a new type of camera singleModeFibre.
* Set the instantaneous Strehl calculation of singleModeFibre to the overlap integral (see: Coudé du Foresto et al., 2000)